### PR TITLE
Reorg doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 # The StarTable data format
 
 StarTable is a human- and machine-readable data format designed to conveniently
-store arbitrary numbers of two-dimensional tables of data. It also supports peripheral information elements such as metadata and application-specific functionality. 
+store an arbitrary number of two-dimensional tables of data. It also supports peripheral information elements such as metadata and application-specific functionality. 
 
 The StarTable format is file-format agnostic. In practice, CSV files and Excel workbooks are most commonly used. But any file format that can be used to represent a set of
-tables, each with columns and rows of cells, can in principle adhere to the StarTable format.
+tables, each with columns and rows of cells, can, in principle, adhere to the StarTable format.
 
-Let's have a high-level, example-based look at the StarTable format. Further details are available in the full [StarTable format specification](https://github.com/startable/startable-standard/blob/master/StarTable%20format%20specification.md).
+## Parsers and utilities
+
+StarTable parsers exist for Python, MATLAB, and C#. They can currently parse StarTable files in CSV and Excel format. 
+
+The StarTable Editor is an Excel add-in that helps humans read, write, quality-control, and prettify StarTable files. 
+
+These have all been developed in private repos, but in March 2019, it was decided to open-source them, and they will be placed on [GitHub](https://github.com/startable) in due course. 
 
 ## Quick overview of the StarTable format
 
-Here is an example StarTable file as viewed in Microsoft Excel. In it you'll see the various block types that StarTable supports, as annotated on the right. 
+Let's have a high-level, example-based look at the StarTable format. Further details are available in the full [StarTable format specification](https://github.com/startable/startable-standard/blob/master/StarTable%20format%20specification.md).
+
+Below is an example StarTable file as viewed in Microsoft Excel. In it you'll see the various block types that StarTable supports, as annotated on the right. 
 
 Blocks are separated by one or more blank lines (except template blocks, which may be contiguous). 
 
@@ -26,7 +34,7 @@ The example file above contains only one table block, but StarTable files can co
 
 Let's take a closer look at the example table block:
 
-![Example table block](C:/Users/JEACO/Source/startable-standard/media/table-block-example.png)
+![Example table block](media/table-block-example.png)
 
 Table blocks start with a cell containing a `**` prefix followed by the *table name*, in this case, `farm_animals`. The table name is usually descriptive of the what the table contains. 
 
@@ -53,8 +61,9 @@ Below the destination are an arbitrary number of columns. Each column starts wit
 
 Here is an illustration of the hierarchical structure of a StarTable file:
 
-![High-level hierarchical structure of the StarTable format](C:/Users/JEACO/Source/startable-standard/media/hierarchical-structure-diagram.png)
+![High-level hierarchical structure of the StarTable format](media/hierarchical-structure-diagram.png)
 
-The StarTable format is file-format-agnostic. A StarTable file can be saved as a CSV file, or as an Excel workbook, or as any other file format that can represent columns and rows. Some of these file formats, such as Excel workbooks, can support multiple *sheets*. Others, such as CSV files, can't; they can contain only one sheet. 
+A StarTable file can be saved as a CSV file, or as an Excel workbook, or as any other file format that can represent columns and rows. Some of these file formats, such as Excel workbooks, can support multiple *sheets*. Others, such as CSV files, can typically contain only one sheet. 
 
 Therefore, a more complete characterization of the example StarTable file shown further above is that it contains only one *sheet*, which in turn only contains one table block (along with a few other blocks of other types). 
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,60 @@
-# startable-standard
+# The StarTable data format
 
-This repo is for documentation about the StarTable standard: format specification and other related things.
+StarTable is a human- and machine-readable data format designed to conveniently
+store arbitrary numbers of two-dimensional tables of data. It also supports peripheral information elements such as metadata and application-specific functionality. 
+
+The StarTable format is file-format agnostic. In practice, CSV files and Excel workbooks are most commonly used. But any file format that can be used to represent a set of
+tables, each with columns and rows of cells, can in principle adhere to the StarTable format.
+
+Let's have a high-level, example-based look at the StarTable format. Further details are available in the full [StarTable format specification](https://github.com/startable/startable-standard/blob/master/StarTable%20format%20specification.md).
+
+## Quick overview of the StarTable format
+
+Here is an example StarTable file as viewed in Microsoft Excel. In it you'll see the various block types that StarTable supports, as annotated on the right. 
+
+Blocks are separated by one or more blank lines (except template blocks, which may be contiguous). 
+
+The type of any given block can be unambiguously determined by the contents of its first cell in the leftmost column. 
+
+![](C:/Users/JEACO/Source/startable-standard/media/block-examples.png)
+
+### Table blocks
+
+*Table blocks* are the meat and potatoes of StarTable. Table blocks are (typically) where you would put most of your data. In some bare-bones cases, this may be the only type of block you'll need in a StarTable file. 
+
+The example file above contains only one table block, but StarTable files can contain an arbitrary number of table blocks – and of any other block type, for that matter. 
+
+Let's take a closer look at the example table block:
+
+![Example table block](C:/Users/JEACO/Source/startable-standard/media/table-block-example.png)
+
+Table blocks start with a cell containing a `**` prefix followed by the *table name*, in this case, `farm_animals`. The table name is usually descriptive of the what the table contains. 
+
+The cell below that is the *destinations* field. It's a list of space-delimited strings that can be used in an application-specific way, typically to establish:
+
+- relationships between various table blocks; or
+- namespaces.
+
+The default destination is `all`, meaning no specific relationship is established, i.e. this table applies to the entire context. 
+
+Below the destination are an arbitrary number of columns. Each column starts with a *column name* in its top cell, followed by the *column unit* in the cell below that. Then follows an arbitrary number of rows containing values. All columns in a table block must have the same number of rows. 
+
+### Super quick intro to all the other block types
+
+*Metadata lines*' first cell ends with a `:`. They indicate something about the StarTable file itself. In the example above, the file's author is indicated in a metadata line. 
+
+*Directive blocks* start with `***` followed by the *directive name*. The contents of directive blocks are to be passed as a cell array to the client application. One use case is "include" statements, indicating to the application that additional StarTable files are to be read. 
+
+*Template blocks* tell us something about the contents of the file; either about the file as a whole, the table immediately preceding the template block, or a column in that table. Template blocks start with one or more `:` depending on their level (three for file, two for table, one for column). 
+
+*Comments* are free-text remarks, analogous to comments in source code. You can write comments pretty much anywhere (between blocks and to the right of blocks), as long as they don't cause ambiguity with other blocks and block types. 
+
+### Overview of the structure of a StarTable file
+
+Here is an illustration of the hierarchical structure of a StarTable file:
+
+![High-level hierarchical structure of the StarTable format](C:/Users/JEACO/Source/startable-standard/media/hierarchical-structure-diagram.png)
+
+The StarTable format is file-format-agnostic. A StarTable file can be saved as a CSV file, or as an Excel workbook, or as any other file format that can represent columns and rows. Some of these file formats, such as Excel workbooks, can support multiple *sheets*. Others, such as CSV files, can't; they can contain only one sheet. 
+
+Therefore, a more complete characterization of the example StarTable file shown further above is that it contains only one *sheet*, which in turn only contains one table block (along with a few other blocks of other types). 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Blocks are separated by one or more blank lines (except template blocks, which m
 
 The type of any given block can be unambiguously determined by the contents of its first cell in the leftmost column. 
 
-![](C:/Users/JEACO/Source/startable-standard/media/block-examples.png)
+![](media/block-examples.png)
 
 ### Table blocks
 

--- a/StarTable format specification.md
+++ b/StarTable format specification.md
@@ -62,6 +62,8 @@ This concludes this quick intro to StarTable. What follows is a more formal, det
 
 ## Level 0 - Low level file structure
 
+Level 0 parser is file-format specific. Splits file in blocks. 
+
 ### File format
 
 The StarTable format is file-format agnostic. To be StarTable-ready, a given file format must be able to represent a
@@ -82,23 +84,21 @@ a file format that can contain multiple sheets are:
 
 In file formats where files can contain multiple sheets, each sheet must
 be named such as to be uniquely identifiable, and the level 0 processing 
-should only include sheets with names matching the ''INPUT_SHEET_NAME_RE'' regexp.
+should only include sheets with names matching the ''INPUT_SHEET_NAME_RE'' regexp. ?????<<< possible feature: an application-specific regex
 
 ### Atomic types and values
 
 Cells each contain a value of one of the following atomic types:
 
 -   String
-
--   Floating-point number
-
--   Integer
-
--   DateTime
+-   Numeric types:
+    -   Floating-point number
+    -   Integer
+    -   DateTime
 
 Empty cells are to be treated as containing an empty string. 
 
-Floating-point and integer cells may not be left empty. Null or missing values may 
+Numeric type cells may not be left empty. Null or missing values may 
 be represented by either of the following valid null markers: `-`, `nan`, `NaN`, or `NAN`.
 
 #### Restrictions on strings
@@ -108,7 +108,7 @@ Strings may not contain characters used to represent the end of a line
 between cell content and the end of a row. Note that this remark applies
 throughout this document: there are a few instances where we indicate
 that a given field can consist of “any string”; this should be
-understood as, any string not including these forbidden characters.
+understood as shorthand for, any string not including these aforementioned forbidden characters.
 
 #### Additional restrictions on symbol strings
 
@@ -133,8 +133,7 @@ type.
 
 Sheets are contained in a file. Some file formats (such as CSV) can contain only one sheet, while others (e.g. Excel workbook) can contain multiple sheets. Since the StarTable format is file-format
 agnostic, files are not part of the StarTable format proper, and a
-detailed discussion of file formats is beyond the scope of this
-document. 
+detailed discussion of file formats is beyond the scope of this document. 
 
 ## Sheets
 
@@ -227,7 +226,11 @@ prefix `**`, with a directive block start marker).
 The destination list is in the first-column cell on the second row of
 the table block. It is a space-delimited list of destination symbols.
 
-??????????
+Use cases:
+
+- Establishing relationshipe between tables
+- Namespacing
+- ???? give examples
 
 #### Table columns
 
@@ -304,11 +307,15 @@ The main purpose of the template system is to aid work on the file level, where 
 
 ### Metadata line block
 
-\#\#\#
+Info about the file. Examples are: author, verified by, etc.
+
+Reader can implement a system of pseudonyms referring to canonical field names. ?????????
 
 ### Directive block
 
-\#\#\#\#
+Syntax is ***
+
+Reader sends these to the application as cell arrays, to be handled by application
 
 Tables without destinations or units
 
@@ -316,47 +323,3 @@ Application-specific
 
 Typical use cases revision history, include, …
 
-## Bonus material
-
-### Level 2 - Block structure
-
-#### Unit mappings
-
-| foo  | bar  |
-| ---- | ---- |
-| 1    | 2    |
-
-#### Template line block
-
-Potential issues:
-conflict: In template-files, we are interested in Level 3 - Inputset structure
-
-While the lower levels could potentially form a basis for a generic file
-format, the semantics described in this level are mostly specific to the
-use in DEWP.
-
-#### Metadata
-
-##### Metadata mapping
-
-##### Revision data table
-
-#### File names
-
-## Appendix A: Low level file format details
-
-### Excel
-
-### CSV - Semicolon-separated file
-
-## Appendix B – parser implementation example
-
-Level -1 – file (possibly containing more than 1 sheet)
-
-Level 0 – sheet
-
-Level 1 - 2D array of atomic values, yield by row
-
-Level 2 – list of blocks (of various types, parsed)
-
-Level 3 – interpret blocks as needed – esp directives

--- a/StarTable format specification.md
+++ b/StarTable format specification.md
@@ -16,85 +16,37 @@ By 2018, the format's use had spread to five independent projects within the com
 
 In February 2019, approval was granted to open source not only the StarTable standard itself, but also the suite of software packages and utilities that allow reading/writing/manipulating/displaying StarTable files in various programming languages and technologies. Governance remains Ørsted-based for the time being, though this is liable to change if, as hoped for, a community of users emerges outside Ørsted. 
 
-## Quick overview of the StarTable format
+This concludes the soft part of this document. What follows is a more formal, detailed, and rigorous description of the StarTable format. 
 
-Before diving into the formal, detailed specification of the StarTable format, let's have a high-level, example-based look at it. 
+## Hierarchical structure
 
-Here is an example StarTable file as viewed in Microsoft Excel. In it you'll see the various block types that StarTable supports, as annotated on the right. The blocks are separated by one or more blank lines. 
-
-![](media/block-examples.png)
-
-### Intro to table blocks
-
-*Table blocks* are the meat and potatoes of StarTable, which is why we'll spend a few lines discussing them here. Table blocks are (typically) where you would put most of your data. In some bare-bone cases, this may be the only type of block you'll really want or need in a StarTable file. 
-
-The example file above contains only one table block, but StarTable files can contain any number of table blocks – and of any other block type, for that matter. Nevertheless, let's take a closer look at the example table block:
-
-![Example table block](media/table-block-example.png)
-
-The first cell of a table block contains the *table name*, in this case, `farm_animals`, preceded by a `**` prefix, which indicates the start of the table block. The table name is usually descriptive of the contents of the table. 
-
-The cell below that is the *destination*; we won't dig into what this is right now, but long story short, it's a fairly free-form list of space-delimited strings that can be used in an application-specific way, typically to establish relationships between various table blocks. The default destination is `all`, meaning no specific relationship is established, i.e. this table applies to the entire context. 
-
-Below the destination are an arbitrary number of columns. Each column starts with a *column name* in its top cell, followed by the *column unit* in the cell below that. Then follows an arbitrary number of rows containing values. All columns in a table block must have the same number of rows. 
-
-### Super quick intro to all the other block types
-
-*Metadata lines* indicate something about the StarTable file itself. In the example above, the file's author is indicated in a metadata line. Their first cell always ends with a `:`.
-
-*Directive blocks* start with `***` followed by the *directive name*. They are fairly free-form and their design and usage is application-specific. 
-
-*Template blocks* tell us something about the contents of the file; either about the file as a whole, the table immediately preceding the template block, or a column in that table. Template blocks start with one or more `:` depending on their level (three for file, two for table, one for column). 
-
-*Comments* are free-text remarks, analogous to comments in source code. You can write comments pretty much anywhere (between blocks and to the right of blocks), as long as they don't cause ambiguity with other blocks and block types. 
-
-### Overview of the structure of a StarTable file
+Data in StarTable format are contained in a file. Since the StarTable format is file-format agnostic, files are not part of the StarTable format proper, and a
+detailed discussion of file formats is beyond the scope of this document. 
 
 Here is an illustration of the hierarchical structure of a StarTable file:
 
 ![High-level hierarchical structure of the StarTable format](media/hierarchical-structure-diagram.png)
 
-The StarTable format is file-format-agnostic. A StarTable file can be saved as a CSV file, or as an Excel workbook, or as any other file format that can represent columns and rows. Some of these file formats, such as Excel workbooks, can support multiple *sheets*. Others, such as CSV files, can't; they can contain only one sheet. 
+The highest-level structure of the StarTable format proper is the
+*sheet*. Some file formats (such as CSV) can contain only one sheet, while others (e.g. Excel workbook) can contain multiple sheets. 
 
-Therefore, a more complete characterization of the example StarTable file shown further above is that it contains only one *sheet*, which in turn only contains one table block (along with a few other blocks of other types). 
+A sheet contains a series of *blocks* of different types. 
 
-This concludes this quick intro to StarTable. What follows is a more formal, detailed, and rigorous description of the StarTable format. 
+Blocks consist of two-dimensional arrays of cells, each containing an *atomic value*. The detailed structure of any given block depends on its type. Blocks of type table are the main data
+container, while other block types provide supplementary information and
+functionality.  
 
-## Level 0 - Low level file structure
+We will now describe each of the members of this hierarchy in turn. 
 
-Level 0 parser is file-format specific. Splits file in blocks. 
-
-### File format
-
-The StarTable format is file-format agnostic. To be StarTable-ready, a given file format must be able to represent a
-two-dimensional array of cells, with the array being of arbitrary length
-and width, and with each cell containing a value of one of the atomic
-types described further below (basically: strings, numbers, datetimes, and valid empty-cell markers). 
-
-Examples of StarTable-ready file formats are CSV (Comma-Separated Values), which can contain only one sheet, and Excel workbooks, which can
-contain multiple sheets. At the time of writing this document, these are
-the only two StarTable file formats used in practice. This
-should not, however, be understood as a formal limitation. In principle,
-nigh any file format could be used for StarTable files – though not
-all to the same degree of convenience. Further conceivable examples of
-a file format that can contain multiple sheets are:
-
-- JSON
-- A compressed zip archive of multiple CSV files.
-
-In file formats where files can contain multiple sheets, each sheet must
-be named such as to be uniquely identifiable, and the level 0 processing 
-should only include sheets with names matching the ''INPUT_SHEET_NAME_RE'' regexp. ?????<<< possible feature: an application-specific regex
-
-### Atomic types and values
+##<a name="atomic-types"></a> Atomic types and values
 
 Cells each contain a value of one of the following atomic types:
 
--   String
--   Numeric types:
-    -   Floating-point number
-    -   Integer
-    -   DateTime
+- String
+- Numeric types:
+  - Floating-point number
+  - Integer
+  - DateTime
 
 Empty cells are to be treated as containing an empty string. 
 
@@ -115,37 +67,41 @@ understood as shorthand for, any string not including these aforementioned forbi
 *Symbols*, such as table names, column names, and destinations, are represented as
 strings. In addition to general restrictions on strings as described above, these *symbol strings* are subject to the following restrictions:
 
--   They may only contain alphanumeric characters and `_` (underscore); and
+- They may only contain alphanumeric characters and `_` (underscore); and
+- The first character may not be a digit. 
 
--   The first character may not be a digit. 
+## File
 
+The StarTable format is file-format agnostic. To be StarTable-ready, a given file format must be able to represent a
+two-dimensional array of cells, with the array being of arbitrary length
+and width, and with each cell containing a value of one of the allowed [atomic
+types](#atomic-types). 
 
-## Hierarchical structure
+Examples of StarTable-ready file formats are CSV (Comma-Separated Values), which can contain only one sheet, and Excel workbooks, which can
+contain multiple sheets. At the time of writing this document, these are
+the only two StarTable file formats used in practice. This
+should not, however, be understood as a formal limitation. In principle,
+nigh any file format could be used for StarTable files – though not
+all to the same degree of convenience. Further conceivable examples of
+a file format that can contain multiple sheets are:
 
-The highest-level structure of the StarTable format proper is the
-*sheet*. A sheet contains a series of *blocks* of different types. Blocks of type table are the main data
-container, while other block types provide supplementary information and
-functionality. 
+- JSON
+- A compressed zip archive of multiple CSV files.
 
-Blocks consist of two-dimensional arrays of cells each containing an
-*atomic value*. The detailed content of blocks depends on the block
-type.
+### Parsing a file into sheets
 
-Sheets are contained in a file. Some file formats (such as CSV) can contain only one sheet, while others (e.g. Excel workbook) can contain multiple sheets. Since the StarTable format is file-format
-agnostic, files are not part of the StarTable format proper, and a
-detailed discussion of file formats is beyond the scope of this document. 
+In file formats where files can contain multiple sheets, each sheet must
+be named such as to be uniquely identifiable. Parsers may include an option to only process sheets with names matching a certain regular expression. 
 
 ## Sheets
 
 A StarTable sheet consists of an arbitrary number of rows, each
-containing an arbitrary number of cells.
+containing an arbitrary number of cells. 
 
-## Level 1 - Logical file structure: Series of blocks
+### Parsing a sheet into blocks
 
-The rows of a StarTable sheet are arranged as a series of “blocks”. Thus Level 1 processing maps a list of sheets to a single list of blocks of the types detailed below.
-
-Any given row on a sheet can only be a member of one block, but all rows need not be in a block. 
-(Rows that are not in a block are treated as “comments”.)
+A sheet's rows can be parsed into a series of blocks. Any given row on a sheet can only be a member of one block, but all rows need not be in a block. 
+(Rows that are not in a block are treated as *comments*.)
 
 The block syntax is designed such that only the first column need be
 considered in order to unambiguously split a sheet i.e. allocate its rows into blocks. Block
@@ -158,20 +114,37 @@ Blocks start when their start marker is encountered, and end when their
 end marker is encountered. Blocks always include their start marker
 cell, but exclude their end marker.
 
-The primary content is placed in “table” blocks, but there are
+## Blocks
+
+The primary content of StarTable files is typically placed in “table” blocks, but there are
 additional block types that provide supplementary information and
 functionality. The different block types are summarized in this table:
 
 | Block type    | Start marker first-column cell content                       | End marker                                             | Description & remarks                                        |
 | ------------- | ------------------------------------------------------------ | ------------------------------------------------------ | ------------------------------------------------------------ |
-| Directive     | String starting with `***`                                   | - Empty first column cell; or<br>- New block start     | Placeholder for a variety of functions e.g.  <br> - Version control <br> - Allowing tables from various sources to be added dynamically to the set of tables statically present in a sheet |
-| Table         | String starting with `**`                                                 (but not `***`) | - Empty first column cell; or <br> - New block start   | Primary data content                                         |
-| Template      | String starting with `:` (one colon, possibly followed by more colons) | -   Empty first column cell; or <br> - New block start | Template data embedded in template files allow input files to be matched against a template, and provide a description of input data. |
-| Metadata line | Any string that: <br />- Ends with `:`, and <br />- Is not a valid start marker for one of the other block types | End of line                                            | Are only accepted at the top of a sheet, before any other block types.<br />Provide information about the current sheet.<br />Always span exactly one line. |
+| Directive     | `***` followed by directive block name                       | - Empty first column cell; or<br>- New block start     | Placeholder for a variety of functions e.g.  <br> - Version control <br> - Allowing tables from various sources to be added dynamically to the set of tables statically present in a sheet |
+| Table         | `**`  followed by table name                                               (which may not start with `*`) | - Empty first column cell; or <br> - New block start   | Primary data content                                         |
+| Template      | Starts with `:`                                              | -   Empty first column cell; or <br> - New block start | Template data embedded in template files allow input files to be matched against a template, and provide a description of input data. |
+| Metadata line | Ends with `:`, and is not a valid start marker for one of the other block types | End of line                                            | Are only accepted at the top of a sheet, before any other block types.<br />Provide information about the current sheet.<br />Always span exactly one line. |
 
 The following sections describe the structure of these block types.
 
-## Level 2 - Block structure
+### Metadata line block
+
+Metadata lines contain information about the file. Typical metadata fields are: author, verified by, etc.
+
+StarTable parsers may implement a system of metadata field pseudonyms referring to canonical field names. 
+
+### Directive block
+
+The first cell starts with `***` followed by a directive name symbol. 
+
+The content of a directive block is to be sent to the client application as cell arrays, to be handled by the application. 
+
+Example use cases:
+
+- Revision history
+- "Include" statements, indicating to the application that additional StarTable files are to be read. 
 
 ### Table block
 
@@ -184,7 +157,6 @@ A table block consists of:
 
 -   An arbitrary number of vertical *table columns*, arranged
     side-by-side horizontally. Each column consists of:
-
     -   A *column name*, describing the contents of the column;
 
     -   A data type / unit indicator, hereafter simply referred to in shorthand as *unit*, used to distinguished between
@@ -194,7 +166,9 @@ A table block consists of:
     -   An arbitrary number of values. All columns within a given
         table must have the same number of rows i.e. values. 
 
-These elements are illustrated in Figure 1 and described further below.
+An example of these elements is illustrated this figure: 
+
+![Example table block](media/table-block-example.png)
 
 
 Generic example of a table block:
@@ -209,28 +183,27 @@ Generic example of a table block:
 | `col 1 val 3`      | `col 2 val 3`    | `col 3 val 3`    | …     |
 | …                  | …                | …                | …     |
 
-
+We will now describe the elements of a table block. 
 
 #### Table name
 
-Along with its prefix `**`, the table name marks the first row of the
+Along with its prefix `**`, the table name symbol marks the first row of the
 table block. It is in the first column.
 
-The table name is intended to describe what the table is about. It can
+The *table name* is intended to describe what the table is about. It can
 be any single-line string subject to restrictions on symbol strings, and
 not starting with `*` (so as not to be confused, in conjunction with its
-prefix `**`, with a directive block start marker).
+prefix `**`, with a directive block start marker, `***`).
 
 #### Destination list
 
 The destination list is in the first-column cell on the second row of
 the table block. It is a space-delimited list of destination symbols.
 
-Use cases:
+The use of destinations is application-specific. Typical use cases include: 
 
-- Establishing relationshipe between tables
+- Establishing relationships between table blocks
 - Namespacing
-- ???? give examples
 
 #### Table columns
 
@@ -246,24 +219,31 @@ The column name must be unique within the current table i.e. no two columns of a
 
 ##### Unit
 
-The second cell of a table column is the *unit*, a data type / unit indicator
-symbol, which specifies how the column’s values should be interpreted.
-Valid indicators and their interpretation are described in the table below.
+The second cell of a table column is the *unit* symbol, where "unit" is used as shorthand for "data type / unit indicator". The unit specifies how the column’s values should be interpreted. It does not necessarily represent a physical unit. 
+Valid units and their interpretation are described in the table below.
 
 | Unit                       | Data type of column values                                   |
 | -------------------------- | ------------------------------------------------------------ |
 | `text`                     | Text                                                         |
 | `datetime`                 | Datetime value, with format conforming to [ISO 8601](https://xkcd.com/1179/). |
 | `-` <br>(a single "minus") | Unitless / non-dimensional numerical values                  |
-| Any other string           | Numerical values with unit specified by the indicator string. |
+| Any other string           | Numerical values with physical unit specified by the unit string. |
 
 
 ##### Values
 
 The remaining cells of a table column contain data values, which can be
-of any of the atomic types listed above.
+of any of the valid atomic types, but must comply with the column's unit.
+
+#### Gotcha: empty string in first column ends table block
+
+Empty string is a legal value for cells in `text` columns. However, if the first column of a table block is of unit `text` and an empty string is encountered in this column, this will trigger the end of the table block. Therefore, empty strings must not be entered in the first column of a table block. 
+
+If an empty string is inadvertently entered mid-column, any data in this and subsequent rows will not be interpreted as being part of this table block. A faithful StarTable parser will interpret them as being comments and ignore them, until the start of a new block is encountered. 
 
 ### Template block
+
+*Template blocks* tell us something about the contents of the file; either about the file as a whole, the table immediately preceding the template block, or a column in that table. 
 
 Template data embedded in template files allow input files to be matched
 against a template, and provide description of input data.
@@ -304,22 +284,4 @@ Examples:
 |                  |                                   |          |
 
 The main purpose of the template system is to aid work on the file level, where destinations cannot be resolved. For this reason, tables are identified by table names only for the purpose of template-matching.
-
-### Metadata line block
-
-Info about the file. Examples are: author, verified by, etc.
-
-Reader can implement a system of pseudonyms referring to canonical field names. ?????????
-
-### Directive block
-
-Syntax is ***
-
-Reader sends these to the application as cell arrays, to be handled by application
-
-Tables without destinations or units
-
-Application-specific
-
-Typical use cases revision history, include, …
 


### PR DESCRIPTION
Reorganize the main docs:
 Move the "quick intro" section out of the main spec doc, into the README to serve as front page. 
 Revert once more out of the "levels"-based explanation of the spec, back to an elements-based explanation. The "levels" thing is more suitable for a prescription of how parsers should be written. This can be added later.