### PR TITLE
Remove the concept of "sheet template", closes #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Let's have a high-level, example-based look at the StarTable format. Further det
 
 Below is an example StarTable file as viewed in Microsoft Excel. In it you'll see the various block types that StarTable supports, as annotated on the right. 
 
-Blocks are separated by one or more blank lines (except template blocks, which may be contiguous). 
+Blocks are separated by one or more blank lines (except template lines, which may be contiguous; and metadata lines, which must be contiguous at the top of the file). 
 
 The type of any given block can be unambiguously determined by the contents of its first cell in the leftmost column. 
 
@@ -73,7 +73,7 @@ Below the destination are an arbitrary number of columns. Each column starts wit
 
 *Directive blocks* start with `***` followed by the *directive name*. The contents of directive blocks are to be passed as a cell array to the client application. One use case is "include" statements, indicating to the application that additional StarTable files are to be read. 
 
-*Template blocks* tell us something about the contents of the file; either about the file as a whole, the table immediately preceding the template block, or a column in that table. Template blocks start with one or more `:` depending on their level (two for table, one for column). 
+*Template lines* tell us something about the expected contents of tables; either a table as a whole, or a column in that table. They are used for matching against templates, and to guide the human user. Template blocks start with one or more `:` depending on their level (two for table, one for column). 
 
 *Comments* are free-text remarks, analogous to comments in source code. You can write comments pretty much anywhere (between blocks and to the right of blocks), as long as they don't cause ambiguity with other blocks and block types. 
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Below the destination are an arbitrary number of columns. Each column starts wit
 
 *Directive blocks* start with `***` followed by the *directive name*. The contents of directive blocks are to be passed as a cell array to the client application. One use case is "include" statements, indicating to the application that additional StarTable files are to be read. 
 
-*Template blocks* tell us something about the contents of the file; either about the file as a whole, the table immediately preceding the template block, or a column in that table. Template blocks start with one or more `:` depending on their level (three for file, two for table, one for column). 
+*Template blocks* tell us something about the contents of the file; either about the file as a whole, the table immediately preceding the template block, or a column in that table. Template blocks start with one or more `:` depending on their level (two for table, one for column). 
 
 *Comments* are free-text remarks, analogous to comments in source code. You can write comments pretty much anywhere (between blocks and to the right of blocks), as long as they don't cause ambiguity with other blocks and block types. 
 

--- a/StarTable format specification.md
+++ b/StarTable format specification.md
@@ -140,12 +140,12 @@ The primary content of StarTable files is typically placed in “table” blocks
 additional block types that provide supplementary information and
 functionality. The different block types are summarized in this table:
 
-| Block type    | Start marker first-column cell content                       | End marker                                             | Description & remarks                                        |
-| ------------- | ------------------------------------------------------------ | ------------------------------------------------------ | ------------------------------------------------------------ |
-| Directive     | `***` followed by directive block name                       | - Empty first column cell; or<br>- New block start     | Placeholder for a variety of functions e.g.  <br> - Version control <br> - Allowing tables from various sources to be added dynamically to the set of tables statically present in a sheet |
-| Table         | `**`  followed by table name, optionally followed by the transpose decorator `*` | - Empty first column cell; or <br> - New block start   | Primary data content                                         |
-| Template      | Starts with `:`                                              | -   Empty first column cell; or <br> - New block start | Template data embedded in template files allow input files to be matched against a template, and provide a description of input data. |
-| Metadata line | Ends with `:`, and is not a valid start marker for one of the other block types | End of line                                            | Are only accepted at the top of a sheet, before any other block types.<br />Provide information about the current sheet.<br />Always span exactly one line. |
+| Block type    | Start marker first-column cell content                       | End marker                                           | Description & remarks                                        |
+| ------------- | ------------------------------------------------------------ | ---------------------------------------------------- | ------------------------------------------------------------ |
+| Directive     | `***` followed by directive block name                       | - Empty first column cell; or<br>- New block start   | Placeholder for a variety of functions e.g.  <br> - Version control <br> - Allowing tables from various sources to be added dynamically to the set of tables statically present in a sheet |
+| Table         | `**`  followed by table name, optionally followed by the transpose decorator `*` | - Empty first column cell; or <br> - New block start | Primary data content                                         |
+| Template line | Starts with `:`                                              | End of line                                          | Template provide a description of the expected input data. Used for matching against templates, and to guide the human user. |
+| Metadata line | Ends with `:`, and is not a valid start marker for one of the other block types | End of line                                          | Are only accepted at the top of a sheet, before any other block types.<br />Provide information about the current sheet.<br />Always span exactly one line. |
 
 The following sections describe the structure of these block types.
 
@@ -280,25 +280,25 @@ The empty string is a legal value for cells in `text` columns. However, if the f
 
 If an empty string is inadvertently entered as part of the first column, any data in this and subsequent rows will not be interpreted as being part of this table block. A faithful StarTable parser will interpret them as being comments and ignore them, until the start of a new block is encountered. 
 
-### Template block
+### Template line
 
-*Template blocks* tell us something about the expected contents of tables; either a table as a whole, or a column in that table. 
+*Template lines* tell us something about the expected contents of tables; either a table as a whole, or a column in that table. 
 Template data allow input files to be validated against a template, and provide a description of the expected input data.
 
-A template block start marker cell has the regex form
+A template line start marker cell has the regex form
 
 ```
 ^(?level:{1:2})(?identifier(\w*))(\.(?property\w+))?\s*$
 ```
 
 The number of colons in the prefix determine the level to which this
-template block applies. The characteristics of the three template block
+template line applies. The characteristics of the two template block
 levels are summarized in this table:
 
 | Start marker prefix | Level  | Identifier must be a… | Default identifier (if omitted)                                                                                                                                                          | Default property (if omitted) |
 |---------------------|--------|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
 | `::` <br>(two colons) | Table  | Table name            | Latest table block | description                   |
-| `:` <br>(a single colon) | Column | Column name           | Most recent column name in a column level template block. <br />It is an error not to specify a column identifier if no valid column level template block has appeared after the most recent table template block. | description                   |
+| `:` <br>(a single colon) | Column | Column name           | Most recent column name in a column level template line. <br />It is an error not to specify a column identifier if no valid column level template block has appeared after the most recent table template line. | description                   |
 
 The property is optional. If it appears, it must be one of:
 

--- a/StarTable format specification.md
+++ b/StarTable format specification.md
@@ -313,12 +313,12 @@ The property is optional. If it appears, it must be one of:
 
 Examples:
 
-| Start marker      | Applies to                          | Property                |
-| ----------------- | ----------------------------------- | ----------------------- |
-| `:n_legs`         | Column `n_legs` in previous table   | `description` (default) |
-| `::farm_animals`  | Table `farm_animals`                | `description` (default) |
-| `:species.choice` | Column `species` in previous table. | `choice`                |
-|                   |                                     |                         |
+| Start marker      | Applies to                           | Property                |
+| ----------------- | ------------------------------------ | ----------------------- |
+| `:n_legs`         | Column `n_legs` in preceding table   | `description` (default) |
+| `::farm_animals`  | Table `farm_animals`                 | `description` (default) |
+| `:species.choice` | Column `species` in preceding table. | `choice`                |
+|                   |                                      |                         |
 
 The main purpose of the template system is to aid work on the file level, where destinations cannot be resolved. For this reason, tables are identified by table names only for the purpose of template-matching.
 

--- a/StarTable format specification.md
+++ b/StarTable format specification.md
@@ -282,15 +282,13 @@ If an empty string is inadvertently entered as part of the first column, any dat
 
 ### Template block
 
-*Template blocks* tell us something about the contents of the file; either about the file as a whole, the table immediately preceding the template block, or a column in that table. 
+*Template blocks* tell us something about the expected contents of tables; either a table as a whole, or a column in that table. 
+Template data allow input files to be validated against a template, and provide a description of the expected input data.
 
-Template data embedded in template files allow input files to be matched
-against a template, and provide description of input data.
-
-Start marker cell has the regex form
+A template block start marker cell has the regex form
 
 ```
-^(?level:{1:3})(?identifier(\w*))(\.(?property\w+))?\s*$
+^(?level:{1:2})(?identifier(\w*))(\.(?property\w+))?\s*$
 ```
 
 The number of colons in the prefix determine the level to which this
@@ -299,15 +297,15 @@ levels are summarized in this table:
 
 | Start marker prefix | Level  | Identifier must be a… | Default identifier (if omitted)                                                                                                                                                          | Default property (if omitted) |
 |---------------------|--------|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|
-| `:::` <br>(three colons) | Sheet  | File name             | Current file name   | description                   |
 | `::` <br>(two colons) | Table  | Table name            | Latest table block | description                   |
-| `:` <br>(a single colon) | Column | Column name           | Most recent column name in a column level block. <br />It is an error not to specify a column identifier if no valid column level template block has appeared after the most recent table block. | description                   |
+| `:` <br>(a single colon) | Column | Column name           | Most recent column name in a column level template block. <br />It is an error not to specify a column identifier if no valid column level template block has appeared after the most recent table template block. | description                   |
 
 The property is optional. If it appears, it must be one of:
 
 | Property name         | Applies to file | Applies to table | Applies to column | Semantics |
 | --------------------- | :--------: | :--------: | :--------: | ---- |
 | `description` (default) | x          | x         | x | Use column 2 as description of this item. Multiple descriptions may be given, in which case a single multi-line description text should be reported. |
+| `choice`              |            |           | x | Column 2 states a valid value for this column. Multiple successive `choice` lines define what values are allowable in this column (similar to an enum); other values are to be considered invalid. |
 | `case`                  |            |           | x | This component is optional |
 | `use_template`         |            |           | x | For each value *s*, the string [col 3]+*s*+[col 4] is a table name for a table that should match the template in [col 2]. |
 | `is_template`          | x          |           | | This table should only be used for templating |
@@ -315,12 +313,12 @@ The property is optional. If it appears, it must be one of:
 
 Examples:
 
-| Start marker     | Applies to                        | Property |
-| ---------------- | --------------------------------- | -------- |
-| `:n_legs`        | Column `n_legs` in previous table | N/A      |
-| `::farm_animals` | Table `farm_animals`              | N/A      |
-|                  |                                   |          |
-|                  |                                   |          |
+| Start marker      | Applies to                          | Property                |
+| ----------------- | ----------------------------------- | ----------------------- |
+| `:n_legs`         | Column `n_legs` in previous table   | `description` (default) |
+| `::farm_animals`  | Table `farm_animals`                | `description` (default) |
+| `:species.choice` | Column `species` in previous table. | `choice`                |
+|                   |                                     |                         |
 
 The main purpose of the template system is to aid work on the file level, where destinations cannot be resolved. For this reason, tables are identified by table names only for the purpose of template-matching.
 


### PR DESCRIPTION
* Removed sheet-level template line (marked by :::) as a concept in the specification. It was poorly defined and not modelled at all in current readers and data structures.

* Renamed the concept of "template _block_" to "template _line_" because the start marker of a template thing really only defines a single line. (Whereas by "block" we typically understand "a block of lines".)  Meh, could go either way TBH.